### PR TITLE
Fix : Default value for pickx should be undef

### DIFF
--- a/lib/puppet/parser/functions/pickx.rb
+++ b/lib/puppet/parser/functions/pickx.rb
@@ -25,7 +25,7 @@ module Puppet::Parser::Functions
     args.delete(:undef)
     args.delete(:undefined)
     args.delete("")
-    args << :undefined
+    args << :undef
     return args[0]
   end
 end


### PR DESCRIPTION
Hi,

When using the puppet-limits module I had an error with the following line

```
  $manage_require = pickx($config_file_require, $limits::config_file_require)
  ....
  file { "limits_conf_${name}":
    ...
    require => $manage_require,
  }
  ...
```

If no $config_file_require nor $limits::config_file_require is defined the value for $manage_require become 'indefined'. When processing puppet throw this exception : 

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: File[limits_conf_mysql.conf] { require => undefined }, because undefined doesn't seem to be in the correct format. Resource references should be formatted as: Classname['title'] or Modulename::Classname['title'] (take careful note of the capitalization).
```

So, I think the default value for the pickx function should be 'undef'.

Regards,
